### PR TITLE
Harden natural gas refresh automation

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,47 +1,34 @@
 name: Update natural gas data
 
 on:
-  # Schedule to run on daily basis at 00:00 UTC
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
-  push:
-    branches:
-      - main
-
-  pull_request:
-    branches:
-      - main
-
-  workflow_dispatch: 
+permissions:
+  contents: write
 
 jobs:
-  build:
+  update:
     runs-on: ubuntu-latest
-
-    if: github.ref == 'refs/heads/main'
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 
     - name: Install Python dependencies
       run: |
-        python -m venv venv
-        source venv/bin/activate
         pip install --upgrade pip
         pip install -r scripts/requirements.txt
 
     - name: Run Make File
       run: |
-          source venv/bin/activate  
-          cd scripts
-          make   
+          make -C scripts
 
     - name: Push and Commit      
       env:

--- a/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
+++ b/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
@@ -1,0 +1,11 @@
+# Update Script Maintenance Report
+
+Date: 2026-03-04
+
+- Re-ran `scripts/process.py`; local outputs already matched currently available upstream files, so no data changes were produced in this run.
+- Updated GitHub Actions automation at `.github/workflows/actions.yml`:
+  - removed push/PR triggers and kept schedule + manual dispatch,
+  - added explicit `permissions: contents: write`,
+  - upgraded to `actions/checkout@v4` and `actions/setup-python@v5`,
+  - simplified script execution via `make -C scripts`.
+- Current freshness gap is tied to EIA publication lag and next daily release timing, not a local pipeline failure.


### PR DESCRIPTION
## Summary
- modernize the existing natural gas workflow by keeping scheduled/manual runs, adding explicit write permissions, and upgrading action versions
- simplify script execution to a stable `make -C scripts` invocation in CI
- add a root maintenance report documenting current publication-lag freshness behavior and verification rerun